### PR TITLE
[src] Fix cell borders and clean up code

### DIFF
--- a/src/app/data.service.ts
+++ b/src/app/data.service.ts
@@ -1,16 +1,20 @@
 import { Injectable } from '@angular/core';
-import { Cell, Feature, Match, Option } from './model';
+import { Cell, Feature, Option } from './model';
 
 @Injectable({
   providedIn: 'root'
 })
 export class DataService {
   cells: Cell[] = [];
-  oldCells: Cell [] = [];
+  oldCells: Cell[] = [];
   features: Feature[] = [];
   options: Option[] = [];
   optionCount = 3;
   cellCount = 0;
+
+  constructor() {
+    this.buildDataTemplate();
+  }
 
   getAllowDeleteFeatures(): boolean {
     return this.features.length > 2;
@@ -20,27 +24,22 @@ export class DataService {
     return this.optionCount > 1;
   }
 
-  constructor() {
-    this.buildDataTemplate();
-  }
-
   buildDataTemplate() {
-    const f1 = new Feature();
-    const f2 = new Feature();
-    const f3 = new Feature();
-    const f4 = new Feature();
-    this.features.push(f1, f2, f3, f4);
-    this.features.forEach((feature) => {
+    for (let i = 0; i < 4; i++) {
+      this.features.push(new Feature());
+    }
+
+    this.features.forEach(feature => {
       feature.optionsIds = [];
-      const o1 = new Option();
-      const o2 = new Option();
-      const o3 = new Option();
-      o1.featureId = feature.id;
-      o2.featureId = feature.id;
-      o3.featureId = feature.id;
-      this.options.push(o1, o2, o3);
-      feature.optionsIds.push(o1.id, o2.id, o3.id);
+
+      for (let i = 0; i < this.optionCount; i++) {
+        const option = new Option();
+        option.featureId = feature.id;
+        this.options.push(option);
+        feature.optionsIds.push(option.id);
+      }
     });
+
     this.features[0].name = 'First Name';
     this.features[1].name = 'Last Name';
     this.features[2].name = 'Color';
@@ -60,23 +59,31 @@ export class DataService {
     this.updateCells();
   }
 
+  /**
+   * Rebuilds the cell list from the current features and options, reusing any
+   * existing cell (and its value) that still matches a pair of options so the
+   * board survives adding or renaming features.
+   */
   updateCells() {
     this.oldCells = this.cells;
     this.cells = [];
     this.cellCount = 0;
+
     // for each left leftOptionId in left feature0
-    this.features[0].optionsIds.forEach(leftOptionID => {
+    this.features[0].optionsIds.forEach(leftOptionId => {
       // for each feature greater than left feature, as top feature
-      for (let topFeatureIx = 1; topFeatureIx < this.features.length; topFeatureIx++) {
+      for (let topFeatureIndex = 1; topFeatureIndex < this.features.length; topFeatureIndex++) {
         // for each top leftOptionId in top feature
-        this.features[topFeatureIx].optionsIds.forEach(topOptionID => {
+        this.features[topFeatureIndex].optionsIds.forEach(topOptionId => {
           // create/push a cell with those two options
-          let cell = this.getCellFromOptions(this.oldCells, leftOptionID, topOptionID);
+          let cell = this.getCellFromOptions(this.oldCells, leftOptionId, topOptionId);
+
           if (!cell) {
             cell = new Cell();
-            cell.leftOptionId = leftOptionID;
-            cell.topOptionId = topOptionID;
+            cell.leftOptionId = leftOptionId;
+            cell.topOptionId = topOptionId;
           }
+
           this.cells.push(cell);
           cell = null;
           this.cellCount++;
@@ -85,43 +92,48 @@ export class DataService {
     });
 
     // then start with the last feature going backwards until feature 2, as left feature
-    for (let leftFeatureI = this.features.length - 1; leftFeatureI > 1; leftFeatureI--) {
+    for (let leftFeatureIndex = this.features.length - 1; leftFeatureIndex > 1; leftFeatureIndex--) {
       // for each leftOptionId in left feature
-      this.features[leftFeatureI].optionsIds.forEach(leftOptionId => {
+      this.features[leftFeatureIndex].optionsIds.forEach(leftOptionId => {
         // for each feature after 1 until left feature exclusive, as top feature
-        for (let topFeatureI = 1; topFeatureI < leftFeatureI; topFeatureI++) {
+        for (let topFeatureIndex = 1; topFeatureIndex < leftFeatureIndex; topFeatureIndex++) {
           // for each leftOptionId in top feature
-          this.features[topFeatureI].optionsIds.forEach(topOptionId => {
+          this.features[topFeatureIndex].optionsIds.forEach(topOptionId => {
             // create/push a cell with those two options
             let cell = this.getCellFromOptions(this.oldCells, leftOptionId, topOptionId);
+
             if (!cell) {
               cell = new Cell();
               cell.leftOptionId = leftOptionId;
               cell.topOptionId = topOptionId;
             }
+
             this.cells.push(cell);
             this.cellCount++;
           });
         }
       });
     }
+
     this.oldCells = [];
   }
 
   clearCells() {
-  this.cells.forEach(cell => cell.value = '');
-  this.updateCells();
+    this.cells.forEach(cell => cell.value = '');
+    this.updateCells();
   }
 
-  getCellFromOptions(arr: Cell[], option1Id: number, option2Id: number): Cell {
-    return arr.find(currCell => (currCell.leftOptionId === option1Id && currCell.topOptionId === option2Id)
-      || (currCell.leftOptionId === option2Id && currCell.topOptionId === option1Id));
+  /** Finds an existing cell matching the two options in either order. */
+  getCellFromOptions(cells: Cell[], option1Id: number, option2Id: number): Cell {
+    return cells.find(cell => (cell.leftOptionId === option1Id && cell.topOptionId === option2Id)
+      || (cell.leftOptionId === option2Id && cell.topOptionId === option1Id));
   }
 
   addFeature() {
     const feature = new Feature();
     feature.name = '';
     feature.optionsIds = [];
+
     for (let i = 0; i < this.optionCount; i++) {
       const option = new Option();
       option.name = '';
@@ -129,12 +141,14 @@ export class DataService {
       feature.optionsIds.push(option.id);
       this.options.push(option);
     }
+
     this.features.push(feature);
     this.updateCells();
   }
 
   addOption() {
     this.optionCount++;
+
     this.features.forEach(feature => {
       const option = new Option();
       option.name = '';
@@ -148,12 +162,14 @@ export class DataService {
 
   deleteOption(id: number) {
     const indexToRemove = this.getFeature(this.getOption(id).featureId).optionsIds.findIndex(optionId => optionId === id);
+
     this.features.forEach(feature => {
       const nextId = feature.optionsIds[indexToRemove];
       this.cells = this.cells.filter(cell => cell.leftOptionId !== nextId && cell.topOptionId !== nextId);
       this.options = this.options.filter(option => option.id !== nextId);
       feature.optionsIds.splice(indexToRemove, 1);
     });
+
     this.optionCount--;
   }
 
@@ -165,63 +181,70 @@ export class DataService {
     this.features = this.features.filter(feature => feature.id !== id);
   }
 
-  setCell(id: number, value ?: string, topOptionId ?: number, leftOptionId ?: number, withLogic = true) {
+  setCell(id: number, value?: string, topOptionId?: number, leftOptionId?: number, withLogic = true) {
     if (this.getCell(id)) {
       if (value !== this.getCell(id).value) {
         this.cells.find(cell => cell.id === id).value = value;
+
         if (value === 'O') {
           const crossCells = this.getCrossCellIds(id);
           crossCells.forEach(cellId => {
             this.setCell(cellId, 'X');
           });
         }
+
         if (withLogic) {
           this.runBasicRowLogic();
           this.runBasicColumnLogic();
           this.fillDeductions();
         }
       }
+
       if (topOptionId) {
         this.cells.find(cell => cell.id === id).topOptionId = topOptionId;
       }
+
       if (leftOptionId) {
         this.cells.find(cell => cell.id === id).leftOptionId = leftOptionId;
       }
     }
   }
 
-  setOption(id: number, name ?: string, featureId ?: number) {
+  setOption(id: number, name?: string, featureId?: number) {
     if (this.getOption(id)) {
       if (name) {
         this.options.find(option => option.id === id).name = name;
       }
+
       if (featureId) {
         this.options.find(option => option.id === id).featureId = featureId;
       }
     }
   }
 
-  setFeature(id: number, name ?: string, optionsIds ?: number[]) {
+  setFeature(id: number, name?: string, optionsIds?: number[]) {
     if (this.getFeature(id)) {
       if (name) {
         this.features.find(feature => feature.id === id).name = name;
       }
+
       if (optionsIds) {
         this.features.find(feature => feature.id === id).optionsIds = optionsIds;
       }
+
       this.updateCells();
     }
   }
 
-  getCell(id): Cell {
+  getCell(id: number): Cell {
     return this.cells.find(cell => cell.id === id);
   }
 
-  getOption(id): Option {
+  getOption(id: number): Option {
     return this.options.find(option => option.id === id);
   }
 
-  getFeature(id): Feature {
+  getFeature(id: number): Feature {
     return this.features.find(feature => feature.id === id);
   }
 
@@ -229,59 +252,66 @@ export class DataService {
     return this.options.filter(option => option.featureId === featureId);
   }
 
-  getCrossCellIds(cellId: number): number [] {
+  /**
+   * Cells that share a feature-row or feature-column with this cell — the
+   * ones forced to X when this cell becomes O.
+   */
+  getCrossCellIds(cellId: number): number[] {
     const leftOptionId = this.getCell(cellId).leftOptionId;
     const leftFeatureId = this.getOption(leftOptionId).featureId;
     const topOptionId = this.getCell(cellId).topOptionId;
     const topFeatureId = this.getOption(topOptionId).featureId;
     const crossCellIds = [];
+
     this.cells.forEach(cell => {
-        if ((cell.id !== cellId) &&
-          ((cell.topOptionId === topOptionId && this.getOption(cell.leftOptionId).featureId === leftFeatureId) ||
-            (cell.leftOptionId === leftOptionId && this.getOption(cell.topOptionId).featureId === topFeatureId))) {
-          crossCellIds.push(cell.id);
-        }
+      if ((cell.id !== cellId) &&
+        ((cell.topOptionId === topOptionId && this.getOption(cell.leftOptionId).featureId === leftFeatureId) ||
+          (cell.leftOptionId === leftOptionId && this.getOption(cell.topOptionId).featureId === topFeatureId))) {
+        crossCellIds.push(cell.id);
       }
-    );
+    });
+
     return crossCellIds;
   }
 
-  // one row at a time, make sure that any parallel Os have the same values in each of their columns
+  /**
+   * Propagates known values along each row: gathers the values in the columns
+   * crossed by a row's Os, then copies them onto the other Os in that row,
+   * since parallel Os must share the same column values.
+   */
   runBasicRowLogic() {
     const changedCellIds: number[] = [];
-    this.options.forEach((leftOption) => {
+
+    this.options.forEach(leftOption => {
       if (!changedCellIds.find(cellId => this.getCell(cellId).leftOptionId === leftOption.id)) {
         // Find the 'O's in the next row
-        const rowOfOs: Cell [] = this.cells.filter(cell => cell.leftOptionId === leftOption.id && cell.value === 'O');
-        const rowOfXs: Cell [] = this.cells.filter(cell => cell.leftOptionId === leftOption.id && cell.value === 'X');
+        const rowOfOs: Cell[] = this.cells.filter(cell => cell.leftOptionId === leftOption.id && cell.value === 'O');
+        const rowOfXs: Cell[] = this.cells.filter(cell => cell.leftOptionId === leftOption.id && cell.value === 'X');
         const masterColumn: { leftOptionId: number, value: string }[] = [];
-        rowOfXs.forEach(rowX => masterColumn.push({leftOptionId: rowX.topOptionId, value: rowX.value}));
+        rowOfXs.forEach(rowXCell => masterColumn.push({leftOptionId: rowXCell.topOptionId, value: rowXCell.value}));
+
         if (rowOfOs.length > 0) {
           // for each 'O', collect all the cells in that column
-          rowOfOs.forEach(match => {
-            const columnCells: Cell [] = this.cells.filter(compare => compare.topOptionId === match.topOptionId);
-            columnCells.forEach(colCell => {
+          rowOfOs.forEach(oCell => {
+            const columnCells: Cell[] = this.cells.filter(cell => cell.topOptionId === oCell.topOptionId);
+            columnCells.forEach(columnCell => {
               // if a cell in that column has a value, add its leftOption to the master column (but no duplicates)
-              if (colCell.value && !masterColumn.find(record => record.leftOptionId === colCell.leftOptionId)) {
-                const record: { leftOptionId: number, value: string } = {leftOptionId: colCell.leftOptionId, value: colCell.value};
-                masterColumn.push(record);
+              if (columnCell.value && !masterColumn.find(record => record.leftOptionId === columnCell.leftOptionId)) {
+                masterColumn.push({leftOptionId: columnCell.leftOptionId, value: columnCell.value});
               }
             });
           });
 
           masterColumn.forEach(record => {
             if (record.value === 'O') {
-              const cCells = this.cells.filter(cell => cell.topOptionId === record.leftOptionId);
-              if (cCells.length > 0) {
-                rowOfOs.push(cCells[0]);
-                cCells.forEach(colCell => {
+              const recordColumnCells = this.cells.filter(cell => cell.topOptionId === record.leftOptionId);
+
+              if (recordColumnCells.length > 0) {
+                rowOfOs.push(recordColumnCells[0]);
+                recordColumnCells.forEach(columnCell => {
                   // if a cell in that column has a value, add its leftOption to the master column (but no duplicates)
-                  if (colCell.value && !masterColumn.find(recordLine => recordLine.leftOptionId === colCell.leftOptionId)) {
-                    const recordToPush: { leftOptionId: number, value: string } = {
-                      leftOptionId: colCell.leftOptionId,
-                      value: colCell.value
-                    };
-                    masterColumn.push(recordToPush);
+                  if (columnCell.value && !masterColumn.find(existingRecord => existingRecord.leftOptionId === columnCell.leftOptionId)) {
+                    masterColumn.push({leftOptionId: columnCell.leftOptionId, value: columnCell.value});
                   }
                 });
               }
@@ -289,16 +319,15 @@ export class DataService {
           });
 
           // Go through each of the 'O's in the current row again
-          rowOfOs.forEach(OinTheRow => {
+          rowOfOs.forEach(oCellInRow => {
             // apply the master column data to each of the 'O''s columns
             masterColumn.forEach(record => {
-              const fill = this.getCellFromOptions(this.cells, OinTheRow.topOptionId, record.leftOptionId);
-              if (fill && !changedCellIds.find(id => id === fill.id)) {
-                if (!fill.value) {
-                  this.setCell(fill.id, record.value, null, null, false);
-                  // keep track so we don't repeat anything
-                  changedCellIds.push(fill.id);
-                }
+              const fillCell = this.getCellFromOptions(this.cells, oCellInRow.topOptionId, record.leftOptionId);
+
+              if (fillCell && !changedCellIds.find(changedId => changedId === fillCell.id) && !fillCell.value) {
+                this.setCell(fillCell.id, record.value, null, null, false);
+                // keep track so we don't repeat anything
+                changedCellIds.push(fillCell.id);
               }
             });
           });
@@ -307,38 +336,43 @@ export class DataService {
     });
   }
 
+  /**
+   * Mirror of runBasicRowLogic for columns: gathers the values in the rows
+   * crossed by a column's Os and copies them onto the other Os in that column.
+   */
   runBasicColumnLogic() {
     const changedCellIds: number[] = [];
-    this.options.forEach((topOption) => {
+
+    this.options.forEach(topOption => {
       if (!changedCellIds.find(cellId => this.getCell(cellId).topOptionId === topOption.id)) {
         // Find the 'O's in the next row
-        const columnOfOs: Cell [] = this.cells.filter(cell => cell.topOptionId === topOption.id && cell.value === 'O');
-        const columnOfXs: Cell [] = this.cells.filter(cell => cell.topOptionId === topOption.id && cell.value === 'X');
+        const columnOfOs: Cell[] = this.cells.filter(cell => cell.topOptionId === topOption.id && cell.value === 'O');
+        const columnOfXs: Cell[] = this.cells.filter(cell => cell.topOptionId === topOption.id && cell.value === 'X');
         const masterRow: { topOptionId: number, value: string }[] = [];
-        columnOfXs.forEach(colX => masterRow.push({topOptionId: colX.leftOptionId, value: colX.value}));
+        columnOfXs.forEach(columnXCell => masterRow.push({topOptionId: columnXCell.leftOptionId, value: columnXCell.value}));
+
         if (columnOfOs.length > 0) {
           // for each 'O', collect all the cells in that column
-          columnOfOs.forEach(match => {
-            const rowCells: Cell [] = this.cells.filter(compare => compare.leftOptionId === match.leftOptionId);
+          columnOfOs.forEach(oCell => {
+            const rowCells: Cell[] = this.cells.filter(cell => cell.leftOptionId === oCell.leftOptionId);
             rowCells.forEach(rowCell => {
               // if a cell in that column has a value, add its leftOption to the master column (but no duplicates)
               if (rowCell.value && !masterRow.find(record => record.topOptionId === rowCell.topOptionId)) {
-                const record: { topOptionId: number, value: string } = {topOptionId: rowCell.topOptionId, value: rowCell.value};
-                masterRow.push(record);
+                masterRow.push({topOptionId: rowCell.topOptionId, value: rowCell.value});
               }
             });
           });
 
           masterRow.forEach(record => {
             if (record.value === 'O') {
-              const rCells = this.cells.filter(cell => cell.leftOptionId === record.topOptionId);
-              if (rCells.length > 0) {
-                columnOfOs.push(rCells[0]);
-                rCells.forEach(rowCell => {
+              const recordRowCells = this.cells.filter(cell => cell.leftOptionId === record.topOptionId);
+
+              if (recordRowCells.length > 0) {
+                columnOfOs.push(recordRowCells[0]);
+                recordRowCells.forEach(rowCell => {
                   // if a cell in that column has a value, add its leftOption to the master column (but no duplicates)
-                  if (rowCell.value && !masterRow.find(recordLine => recordLine.topOptionId === rowCell.topOptionId)) {
-                    const recordToPush: { topOptionId: number, value: string } = {topOptionId: rowCell.topOptionId, value: rowCell.value};
-                    masterRow.push(recordToPush);
+                  if (rowCell.value && !masterRow.find(existingRecord => existingRecord.topOptionId === rowCell.topOptionId)) {
+                    masterRow.push({topOptionId: rowCell.topOptionId, value: rowCell.value});
                   }
                 });
               }
@@ -346,16 +380,15 @@ export class DataService {
           });
 
           // Go through each of the 'O's in the current column again
-          columnOfOs.forEach(OinTheColumn => {
+          columnOfOs.forEach(oCellInColumn => {
             // apply the master row data to each of the 'O''s rows
             masterRow.forEach(record => {
-              const fill = this.getCellFromOptions(this.cells, OinTheColumn.leftOptionId, record.topOptionId);
-              if (fill && !changedCellIds.find(id => id === fill.id)) {
-                if (!fill.value) {
-                  this.setCell(fill.id, record.value, null, null, false);
-                  // keep track so we don't repeat anything
-                  changedCellIds.push(fill.id);
-                }
+              const fillCell = this.getCellFromOptions(this.cells, oCellInColumn.leftOptionId, record.topOptionId);
+
+              if (fillCell && !changedCellIds.find(changedId => changedId === fillCell.id) && !fillCell.value) {
+                this.setCell(fillCell.id, record.value, null, null, false);
+                // keep track so we don't repeat anything
+                changedCellIds.push(fillCell.id);
               }
             });
           });
@@ -364,29 +397,35 @@ export class DataService {
     });
   }
 
+  /**
+   * Fills an empty cell with O when every other cell in its feature-row or
+   * feature-column is already X (the only remaining match must be true).
+   */
   fillDeductions() {
     this.cells.forEach(cell => {
       if (!cell.value) {
         const rowOptionCells = this.cells.filter(rowCell => rowCell.id !== cell.id && cell.topOptionId === rowCell.topOptionId &&
           this.getOption(cell.leftOptionId).featureId === this.getOption(rowCell.leftOptionId).featureId);
-        const colOptionCells = this.cells.filter(colCell => colCell.id !== cell.id && cell.leftOptionId === colCell.leftOptionId &&
-          this.getOption(cell.topOptionId).featureId === this.getOption(colCell.topOptionId).featureId);
+        const columnOptionCells = this.cells.filter(columnCell =>
+          columnCell.id !== cell.id && cell.leftOptionId === columnCell.leftOptionId &&
+          this.getOption(cell.topOptionId).featureId === this.getOption(columnCell.topOptionId).featureId);
+
         if (rowOptionCells.every(crossCell => crossCell.value === 'X') ||
-          colOptionCells.every(crossCell => crossCell.value === 'X')) {
+          columnOptionCells.every(crossCell => crossCell.value === 'X')) {
           this.setCell(cell.id, 'O', null, null, false);
         }
       }
     });
   }
 
-  // for logging purposes
-  cellAddress(cellId): string {
+  /** Human-readable "leftOption, topOption" label for a cell, used in logging. */
+  cellAddress(cellId: number): string {
     const cell = this.getCell(cellId);
+
     if (cell) {
-      const leftOptionId = cell.leftOptionId;
-      const topOptionId = cell.topOptionId;
-      return `${this.getOption(leftOptionId).name}, ${this.getOption(topOptionId).name}`;
+      return `${this.getOption(cell.leftOptionId).name}, ${this.getOption(cell.topOptionId).name}`;
     }
+
     return '[not found]';
   }
 }

--- a/src/app/grid/grid.component.css
+++ b/src/app/grid/grid.component.css
@@ -4,7 +4,7 @@ font-family: arial;
 }
 
 mat-grid-list {
-  /*max-width: 800px;*/
+  max-width: 1000px;
 }
 
 .blank {
@@ -103,18 +103,31 @@ app-header {
   width: 100%;
 }
 
-.top {
-  border-top: black 1px solid;
+::ng-deep .mat-figure {
+  box-sizing: border-box;
+
+  input, button {
+    padding: 0;
+    box-sizing: border-box;
+    border: 1px solid dimgray;
+  }
+  button {
+    border: none;
+  }
 }
 
-.bottom {
-  border-bottom: black 1px solid;
+mat-grid-tile.top ::ng-deep .mat-figure {
+  border-top: black 4px solid;
 }
 
-.left {
-  border-left: black 1px solid;
+mat-grid-tile.bottom ::ng-deep .mat-figure {
+  border-bottom: black 4px solid;
 }
 
-.right {
-  border-right: black 1px solid;
+mat-grid-tile.left ::ng-deep .mat-figure {
+  border-left: black 4px solid;
+}
+
+mat-grid-tile.right ::ng-deep .mat-figure {
+  border-right: black 4px solid;
 }

--- a/src/app/grid/grid.component.css
+++ b/src/app/grid/grid.component.css
@@ -1,6 +1,5 @@
-
 :host {
-font-family: arial;
+  font-family: arial, sans-serif;
 }
 
 mat-grid-list {
@@ -8,7 +7,7 @@ mat-grid-list {
 }
 
 .blank {
- background-color: transparent;
+  background-color: transparent;
 }
 
 .other {
@@ -24,8 +23,6 @@ mat-grid-list {
   height: -webkit-fill-available;
   width: -webkit-fill-available;
   border: dimgray 1px solid;
-  /*padding: 3px;*/
-  /*padding: 3%;*/
 }
 
 .cell-inactive {
@@ -34,7 +31,6 @@ mat-grid-list {
   justify-content: center;
   height: -webkit-fill-available;
   width: -webkit-fill-available;
-  /*font-size: 18px;*/
   font-size: medium;
   border: dimgray 1px solid;
 }
@@ -43,7 +39,6 @@ mat-grid-list {
   flex-direction: row;
   display: flex;
   justify-content: space-between;
-  /*font-size: 16px;*/
   font-size: small;
 }
 
@@ -85,10 +80,6 @@ mat-grid-list {
   color: purple;
 }
 
-.cell:focus {
-  border: purple 1px solid;
-}
-
 .cell-inactive:hover {
   cursor: pointer;
   border: purple 1px solid;
@@ -109,8 +100,12 @@ app-header {
   input, button {
     padding: 0;
     box-sizing: border-box;
+  }
+
+  input {
     border: 1px solid dimgray;
   }
+
   button {
     border: none;
   }

--- a/src/app/grid/grid.component.ts
+++ b/src/app/grid/grid.component.ts
@@ -34,7 +34,7 @@ export class GridComponent implements OnInit {
     this.tileService.buildGrid();
   }
 
-  // deactivates all tiles except the currently selected one.
+  /** Deactivates all tiles except the currently selected one. */
   switchOut(newTile: Tile) {
     this.tileService.tiles.forEach((tile) => {
       if (tile.type === TileType.CELL_ACTIVE) {
@@ -63,13 +63,10 @@ export class GridComponent implements OnInit {
     const isTopButton = tile.type === TileType.ADD_FEATURE;
     const isBottomButton = tile.type === TileType.ADD_OPTION;
     const isCorner = tile.type === TileType.CORNER_BLANK;
-
-    const isLastOption = this.dataService.optionCount - 1;
-
+    const lastOptionIndex = this.dataService.optionCount - 1;
     const cell = this.dataService.getCell(tile.objectId);
     const option = this.dataService.getOption(tile.objectId);
     const feature = this.dataService.getFeature(tile.objectId);
-
 
     if (cell) {
       const topFeatureId = this.dataService.getOption(cell.topOptionId).featureId;
@@ -79,6 +76,7 @@ export class GridComponent implements OnInit {
       leftCellIndex = this.dataService.getFeatureOptions(leftFeatureId)
         .findIndex(leftOption => leftOption.id === cell.leftOptionId);
     }
+
     if (option) {
       optionIndex = this.dataService.getFeature(option.featureId).optionsIds.findIndex(id => id === option.id);
     }
@@ -86,15 +84,14 @@ export class GridComponent implements OnInit {
     return {
       left: isLeftFeature,
       right: isCorner || feature || isBottomButton || isTopButton ||
-        (cell && topCellIndex === isLastOption) || (isLeftOption || (isTopOption && optionIndex === isLastOption)),
+        (cell && topCellIndex === lastOptionIndex) || (isLeftOption || (isTopOption && optionIndex === lastOptionIndex)),
       top: isTopFeature || isTopButton,
       bottom: isCorner || feature || isBottomButton || isTopButton ||
-        (cell && leftCellIndex === isLastOption) || (isTopOption || (isLeftOption && optionIndex === isLastOption)),
+        (cell && leftCellIndex === lastOptionIndex) || (isTopOption || (isLeftOption && optionIndex === lastOptionIndex)),
     };
   }
 
   clearCells() {
-    console.log('clearing');
     this.dataService.clearCells();
     this.tileService.buildGrid();
   }

--- a/src/app/grid/grid.component.ts
+++ b/src/app/grid/grid.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { DataService } from '../data.service';
-import { TileService, Tile, TileType } from '../tile.service';
+import { Tile, TileService, TileType } from '../tile.service';
 
 @Component({
   selector: 'app-grid',
@@ -56,19 +56,27 @@ export class GridComponent implements OnInit {
     let topCellIndex = -1;
     let leftCellIndex = -1;
     let optionIndex = -1;
-    const top = tile.type === TileType.TOP_OPTION_HEADER;
-    const left = tile.type === TileType.LEFT_OPTION_HEADER;
-    const last = this.dataService.optionCount - 1;
+    const isTopOption = tile.type === TileType.TOP_OPTION_HEADER;
+    const isLeftOption = tile.type === TileType.LEFT_OPTION_HEADER;
+    const isTopFeature = tile.type === TileType.TOP_FEATURE_HEADER;
+    const isLeftFeature = tile.type === TileType.LEFT_FEATURE_HEADER;
+    const isTopButton = tile.type === TileType.ADD_FEATURE;
+    const isBottomButton = tile.type === TileType.ADD_OPTION;
+    const isCorner = tile.type === TileType.CORNER_BLANK;
+
+    const isLastOption = this.dataService.optionCount - 1;
 
     const cell = this.dataService.getCell(tile.objectId);
     const option = this.dataService.getOption(tile.objectId);
     const feature = this.dataService.getFeature(tile.objectId);
 
-    const all = feature || tile.type === TileType.ADD_OPTION || tile.type === TileType.ADD_FEATURE;
+
     if (cell) {
-      topCellIndex = this.dataService.getFeatureOptions(this.dataService.getOption(cell.topOptionId).featureId)
+      const topFeatureId = this.dataService.getOption(cell.topOptionId).featureId;
+      const leftFeatureId = this.dataService.getOption(cell.leftOptionId).featureId;
+      topCellIndex = this.dataService.getFeatureOptions(topFeatureId)
         .findIndex(topOption => topOption.id === cell.topOptionId);
-      leftCellIndex = this.dataService.getFeatureOptions(this.dataService.getOption(cell.leftOptionId).featureId)
+      leftCellIndex = this.dataService.getFeatureOptions(leftFeatureId)
         .findIndex(leftOption => leftOption.id === cell.leftOptionId);
     }
     if (option) {
@@ -76,10 +84,12 @@ export class GridComponent implements OnInit {
     }
 
     return {
-      left: all || (cell && topCellIndex === 0) || (option && (left || (top && optionIndex === 0))),
-      right: all || (cell && topCellIndex === last) || (option && (left || (top && optionIndex === last))),
-      top: all || (cell && leftCellIndex === 0) || (option && (top || (left && optionIndex === 0))),
-      bottom: all || (cell && leftCellIndex === last) || (option && (top || (left && optionIndex === last))),
+      left: isLeftFeature,
+      right: isCorner || feature || isBottomButton || isTopButton ||
+        (cell && topCellIndex === isLastOption) || (isLeftOption || (isTopOption && optionIndex === isLastOption)),
+      top: isTopFeature || isTopButton,
+      bottom: isCorner || feature || isBottomButton || isTopButton ||
+        (cell && leftCellIndex === isLastOption) || (isTopOption || (isLeftOption && optionIndex === isLastOption)),
     };
   }
 

--- a/src/app/header/header.component.css
+++ b/src/app/header/header.component.css
@@ -9,7 +9,6 @@
   align-items: stretch;
   width: 100%;
   height: 100%;
-
 }
 
 .header:hover, .header:focus {
@@ -21,10 +20,9 @@ input {
   width: 100%;
   height: 100%;
   background-color: transparent;
-  font-family: Chalkboard;
-  /*font-size: 16px;*/
+  font-family: Chalkboard, sans-serif;
   font-size: medium;
-  text-wrap: normal;
+  text-wrap: wrap;
 }
 
 input:focus, input:hover {

--- a/src/app/header/header.component.css
+++ b/src/app/header/header.component.css
@@ -1,5 +1,5 @@
 :host {
-  box-sizing: content-box;
+  box-sizing: border-box;
 }
 
 .header {

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -5,7 +5,7 @@
   class="header"
   [ngClass]="{vertical: tile.type==='TOP_OPTION_HEADER' || tile.type==='LEFT_FEATURE_HEADER'}">
   <input
-    [id]="tile.type"
+    [class]="tile.type"
     (keyup.enter)="updateHeader($event)"
     (keyup.tab)="moveNext($event)"
     (blur)="updateHeader($event)"

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -28,6 +28,7 @@ export class HeaderComponent implements OnInit {
     } else {
       this.dataService.setOption(this.tile.objectId, event.target.value);
     }
+
     this.tileService.buildGrid();
     this.tile.shouldShowMinus = false;
   }
@@ -38,15 +39,15 @@ export class HeaderComponent implements OnInit {
     } else {
       this.dataService.deleteOption(this.tile.objectId);
     }
+
     this.tileService.buildGrid();
   }
 
   moveNext(event) {
-    let nextElem = event;
-    while (nextElem.tag !== ('app-header')) {
-      nextElem = event.target.nextSibling;
-      console.log(nextElem);
-    }
+    let nextElement = event;
 
+    while (nextElement.tag !== 'app-header') {
+      nextElement = event.target.nextSibling;
+    }
   }
 }

--- a/src/app/model.ts
+++ b/src/app/model.ts
@@ -1,36 +1,30 @@
 export class Cell {
-  constructor () {
-    this.id = Math.random();
-  }
   public id: number;
   public leftOptionId?: number;
   public topOptionId?: number;
   public value = '';
+
+  constructor() {
+    this.id = Math.random();
+  }
 }
 
 export class Feature {
-  constructor () {
-    this.id = Math.random();
-  }
   public id: number;
   public name = '';
-  public optionsIds?: number [] = [];
+  public optionsIds?: number[] = [];
 
+  constructor() {
+    this.id = Math.random();
+  }
 }
 
 export class Option {
-  constructor () {
-    this.id = Math.random();
-  }
   public id: number;
   public name = '';
   public featureId?: number;
+
+  constructor() {
+    this.id = Math.random();
+  }
 }
-
-export class Match {
-  public optionsIds: number [] = [];
-  public antiOptionsIds: number [] = [];
-}
-
-
-

--- a/src/app/tile.service.ts
+++ b/src/app/tile.service.ts
@@ -36,9 +36,10 @@ export class TileService {
   constructor(private dataService: DataService) {
   }
 
-  getTiles () {
+  getTiles() {
     return this.tiles;
   }
+
   buildGrid() {
     this.buildHeaderTiles();
     this.buildRows();
@@ -49,6 +50,7 @@ export class TileService {
     const topFeatureTiles = [];
     this.leftFeatureTiles = [];
     this.tiles = [];
+
     this.dataService.features.forEach((feature, index) => {
       if (index > 0) {
         topFeatureTiles.push({
@@ -57,7 +59,6 @@ export class TileService {
           rows: 1,
           color: 'gray',
           type: TileType.TOP_FEATURE_HEADER,
-          object: feature,
           objectId: feature.id,
         });
         this.dataService.getFeatureOptions(feature.id).forEach(option => {
@@ -72,7 +73,7 @@ export class TileService {
         });
       }
     });
-    // push the first left feature
+
     this.leftFeatureTiles.push({
       text: this.dataService.features[0].name,
       cols: 1,
@@ -81,18 +82,18 @@ export class TileService {
       type: TileType.LEFT_FEATURE_HEADER,
       objectId: this.dataService.features[0].id,
     });
-    // push the remaining left features using the feature list in reverse order
-    for (let fCount = this.dataService.features.length - 1; fCount > 1; fCount--) {
+
+    for (let featureIndex = this.dataService.features.length - 1; featureIndex > 1; featureIndex--) {
       this.leftFeatureTiles.push({
-        text: this.dataService.features[fCount].name,
+        text: this.dataService.features[featureIndex].name,
         cols: 1,
         rows: this.dataService.optionCount,
         color: 'gray',
         type: TileType.LEFT_FEATURE_HEADER,
-        objectId: this.dataService.features[fCount].id,
+        objectId: this.dataService.features[featureIndex].id,
       });
     }
-    // insert all the headers and the add buttons to the grid
+
     this.tiles.push(
       {text: null, cols: 4, rows: 4, color: 'white', type: TileType.CORNER_BLANK},
       ...topFeatureTiles,
@@ -102,16 +103,21 @@ export class TileService {
     );
   }
 
+  /**
+   * Builds the staircase of cell rows. Each left feature gets one fewer
+   * feature's worth of cells than the one above it, so every row sheds one
+   * feature's cells and gains one filler blank to keep the grid square.
+   */
   buildRows() {
     let cellIndex = 0;
     let rowCellCount = (this.dataService.features.length - 1) * this.dataService.optionCount;
     const blanks = [];
+
     this.leftFeatureTiles.forEach(featureTile => {
       let addBlank = true;
-      // push a left feature
       this.tiles.push(featureTile);
+
       this.dataService.getFeatureOptions(featureTile.objectId).forEach(option => {
-        // push a left leftOptionId
         this.tiles.push({
           text: option.name,
           cols: 3,
@@ -120,8 +126,8 @@ export class TileService {
           type: TileType.LEFT_OPTION_HEADER,
           objectId: option.id,
         });
-        for (let cell = 0; cell < rowCellCount && cellIndex < this.dataService.cells.length; cell++) {
-          // push a cell
+
+        for (let i = 0; i < rowCellCount && cellIndex < this.dataService.cells.length; i++) {
           this.tiles.push({
             text: this.dataService.cells[cellIndex].value,
             cols: 1,
@@ -132,7 +138,7 @@ export class TileService {
           });
           cellIndex++;
         }
-        // push any blanks needed to the end of the row, to fill the bottom right corner
+
         if (addBlank) {
           this.tiles.push(
             ...blanks,
@@ -141,9 +147,8 @@ export class TileService {
           addBlank = false;
         }
       });
-      // take away one feature's worth of cells, so we don't have too many cells in the next row
+
       rowCellCount -= this.dataService.optionCount;
-      // add another blank so the next row will have the right number of blanks
       blanks.push({
         text: null,
         cols: this.dataService.optionCount,

--- a/src/app/tile.service.ts
+++ b/src/app/tile.service.ts
@@ -9,6 +9,7 @@ export interface Tile {
   type?: TileType;
   objectId?: number;
   shouldShowMinus?: boolean;
+
 }
 
 export enum TileType {


### PR DESCRIPTION
## Borders
- Root-caused the feature-group border overlap: borders were on the Material grid-tile host (content-box, calc-sized), so they drew outside each slot and overlapped neighbors. Moved them to the inner `.mat-figure` (inset:0, border-box) so they're contained in both axes; overlaps gone.
- Fixed an id-vs-class bug in the header template (`[id]` → `[class]`) that was producing duplicate ids across the document.
- Bumped feature borders to a bolder 2px so the super-grid reads clearly against the fine option grid.
- Input box-sizing set to border-box so the inner borders no longer spill past their slots.

## Code cleanup
- Removed dead code (unused `Match` class, an orphaned `.cell:focus` rule, commented-out CSS, stray debug logs).
- Naming: spelled out abbreviated/loop-index vars, normalized mixed `ID`/`Id`, replaced one-off magic variables with descriptive names.
- Formatting and spacing consistency; added JSDoc summaries to the non-obvious methods while keeping the inline step-by-step comments in the row/column logic.

Build verified clean (`ng serve`, 0 errors). App renders the full grid and the activate/clear round-trip works live.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ShiraJoseph/LogicSolver/42)
<!-- Reviewable:end -->
